### PR TITLE
fix(ci): pass --project_id to bq to prevent CLOUDSDK_CORE_PROJECT override

### DIFF
--- a/.github/cleanup-unit.sh
+++ b/.github/cleanup-unit.sh
@@ -20,7 +20,7 @@ TABLES=(
 
 for TABLE in "${TABLES[@]}"; do
   echo "🗑️  Deleting table ${TABLE}..."
-  bq rm -f -t "${PROJECT_ID}:${DATASET}.${TABLE}" || echo "⚠️ Table ${TABLE} not found, skipping."
+  bq rm --project_id="${PROJECT_ID}" -f -t "${PROJECT_ID}:${DATASET}.${TABLE}" || echo "⚠️ Table ${TABLE} not found, skipping."
 done
 
 echo "✅ Test tables cleaned up successfully"

--- a/.github/setup-unit.sh
+++ b/.github/setup-unit.sh
@@ -13,7 +13,7 @@ gcloud config set project "${PROJECT_ID}" >/dev/null
 echo "📋 Creating test tables in existing dataset ${PROJECT_ID}:${DATASET}..."
 
 # orderDetail table: used in 'run' and 'error' tests
-bq query --use_legacy_sql=false "
+bq query --project_id="${PROJECT_ID}" --use_legacy_sql=false "
 CREATE OR REPLACE TABLE \`${PROJECT_ID}.${DATASET}.orderDetail\` AS
 SELECT 1 AS id, 10.5 AS unitPrice, TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY) AS addedDate
 UNION ALL
@@ -21,7 +21,7 @@ SELECT 2 AS id, 200.0 AS unitPrice, TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 
 "
 
 # territory table: used in 'failed' test
-bq query --use_legacy_sql=false "
+bq query --project_id="${PROJECT_ID}" --use_legacy_sql=false "
 CREATE OR REPLACE TABLE \`${PROJECT_ID}.${DATASET}.territory\` AS
 SELECT 1 AS id, 'North' AS name, 1 AS regionId
 UNION ALL


### PR DESCRIPTION
## Summary

- `secrets-to-env-action` leaks `CLOUDSDK_CORE_PROJECT=kestra-host` into all CI steps (side-effect of the GCP maven-remote proxy work in `kestra-io/actions`)
- `gcloud config set project` is silently overridden by that env var
- `bq` commands run against `kestra-host` instead of `kestra-unit-test`, causing `Access Denied: bigquery.jobs.create`
- Fix: pass `--project_id="${PROJECT_ID}"` explicitly to all `bq` calls in both `setup-unit.sh` and `cleanup-unit.sh`

## Related

Failing run: https://github.com/kestra-io/plugin-soda/actions/runs/28219219949/job/83596598956

## Test plan

- [ ] CI passes on this PR with BigQuery table setup/cleanup succeeding